### PR TITLE
Center map on first upcoming event location

### DIFF
--- a/source/events.json
+++ b/source/events.json
@@ -2,7 +2,7 @@
   "location": "San Francisco, CA",
   "hostName": "thoughtbot",
   "rsvpUrl": "http://plibmttbhgaty.com",
-  "date": "April 14, 2016"
+  "date": "May 07, 2016"
 },
 
 {
@@ -15,5 +15,5 @@
   "location": "Melbourne, VIC",
   "hostName": "FastMail",
   "rsvpUrl": "https://t.co/FbiKVEryTy",
-  "date": "May 07, 2016"
+  "date": "April 14, 2016"
 }]

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -22,6 +22,7 @@ per_page: 10
 
     <ul class="events-list past-events-list" id="past-events-list"></ul>
   </div>
+
   <div id="event-map"></div>
 </section>
 

--- a/source/javascripts/event-map.js
+++ b/source/javascripts/event-map.js
@@ -11,6 +11,7 @@ function addInfoWindow(marker, event) {
                       '<h1 class="info-heading">' + event["location"] + '</h1>' +
                       '<ul>' +
                       '<li><b>Host:</b> ' + event["hostName"] + '</li>' +
+                      '<li><b>Date:</b> ' + event["date"] + '</li>' +
                       '<li><b>RSVP:</b> ' + event["rsvpUrl"] + '</li>' +
                       '</ul>' +
                       '<center><a href="' + event["more-info"] + '">More Information</b></a><br><br>';
@@ -22,6 +23,19 @@ function addInfoWindow(marker, event) {
   marker.addListener('click', function() {
     infoWindow.open(map, marker);
   });
+
+  return infoWindow;
+}
+
+function drawMarker(title, latlong) {
+  var marker = new google.maps.Marker({
+    position: latlong,
+    map: map,
+    title: title
+  });
+
+  markers.push(marker);
+  return marker
 }
 
 // Geocodes the given location
@@ -29,17 +43,10 @@ function codeAddress(data) {
   geocoder.geocode({ 'address': data["location"] }, function(results, status) {
     if (status == google.maps.GeocoderStatus.OK) {
       var latlong = results[0].geometry.location;
-      console.log(latlong);
 
-      var marker = new google.maps.Marker({
-        position: latlong,
-        map: map,
-        title: data["title"]
-      });
-
-      markers.push(marker);
-
-      addInfoWindow(marker, data);
+      var marker = drawMarker(data["title"], latlong);
+      var infoWindow = addInfoWindow(marker, data);
+      centerMapOnFirstMarker(marker, latlong, infoWindow);
     }
   });
 }
@@ -51,14 +58,30 @@ function nullAllMarkers(map) {
   }
 }
 
-function updateMarkers() {
+function updateMarkers(data) {
   nullAllMarkers();
 
-  $.get('/events.json', {}, function(data) {
-    for (var i = 0; i < data.length; i++) {
+  for (var i = 0; i < data.length; i++) {
+    var currentDate = Date.now()
+    var event = data[i];
+    var eventDate = Date.parse(event.date);
+
+    if (eventIsUpcoming(eventDate)) {
       codeAddress(data[i]);
-    }
-  });
+    };
+  }
+}
+
+function centerMapOnFirstMarker(marker, latlong, infoWindow) {
+  if (markers.indexOf(marker) === 0){
+    map.setCenter({
+      lat: latlong.lat(),
+      lng: latlong.lng()
+    });
+    map.setZoom(3);
+
+    infoWindow.open(map, marker);
+  }
 }
 
 // When the window has finished loading, create our Google map below
@@ -67,22 +90,24 @@ google.maps.event.addDomListener(window, 'load', init);
 function init() {
     // Initializes geocoding with Google Maps API
     geocoder = new google.maps.Geocoder();
+    $.get('/events.json', {}, function(data) {
 
-    // Basic operations for a simple Google Map
-    // For more options see:
-    // https://developers.google.com/maps/documentation/javascript/reference#MapOptions
-    var mapOptions = {
-        zoom: 2,
-        center: new google.maps.LatLng(40.6700, -73.9400), // NYC
-        disableDefaultUI: true,
-        scrollwheel: false,
-        styles: [{"featureType":"administrative","elementType":"labels.text.fill","stylers":[{"color":"#ffffff"}]},{"featureType":"landscape","elementType":"all","stylers":[{"color":"#f2f2f2"}]},{"featureType":"landscape","elementType":"geometry.fill","stylers":[{"color":"#ffffff"}]},{"featureType":"poi","elementType":"all","stylers":[{"visibility":"off"}]},{"featureType":"poi.park","elementType":"geometry.fill","stylers":[{"color":"#e6f3d6"},{"visibility":"on"}]},{"featureType":"road","elementType":"all","stylers":[{"saturation":-100},{"lightness":45},{"visibility":"simplified"}]},{"featureType":"road.highway","elementType":"all","stylers":[{"visibility":"simplified"}]},{"featureType":"road.highway","elementType":"geometry.fill","stylers":[{"color":"#f4d2c5"},{"visibility":"simplified"}]},{"featureType":"road.highway","elementType":"labels.text","stylers":[{"color":"#4e4e4e"}]},{"featureType":"road.arterial","elementType":"geometry.fill","stylers":[{"color":"#f4f4f4"}]},{"featureType":"road.arterial","elementType":"labels.text.fill","stylers":[{"color":"#787878"}]},{"featureType":"road.arterial","elementType":"labels.icon","stylers":[{"visibility":"off"}]},{"featureType":"transit","elementType":"all","stylers":[{"visibility":"off"}]},{"featureType":"water","elementType":"all","stylers":[{"color":"#eaf6f8"},{"visibility":"on"}]},{"featureType":"water","elementType":"geometry.fill","stylers":[{"color":"#eaf6f8"}]}]
-    };
+      // Basic operations for a simple Google Map
+      // For more options see:
+      // https://developers.google.com/maps/documentation/javascript/reference#MapOptions
+      var mapOptions = {
+          zoom: 2,
+          center: new google.maps.LatLng(40.6700, -73.9400), // NYC
+          disableDefaultUI: true,
+          scrollwheel: false,
+          styles: [{"featureType":"administrative","elementType":"labels.text.fill","stylers":[{"color":"#ffffff"}]},{"featureType":"landscape","elementType":"all","stylers":[{"color":"#f2f2f2"}]},{"featureType":"landscape","elementType":"geometry.fill","stylers":[{"color":"#ffffff"}]},{"featureType":"poi","elementType":"all","stylers":[{"visibility":"off"}]},{"featureType":"poi.park","elementType":"geometry.fill","stylers":[{"color":"#e6f3d6"},{"visibility":"on"}]},{"featureType":"road","elementType":"all","stylers":[{"saturation":-100},{"lightness":45},{"visibility":"simplified"}]},{"featureType":"road.highway","elementType":"all","stylers":[{"visibility":"simplified"}]},{"featureType":"road.highway","elementType":"geometry.fill","stylers":[{"color":"#f4d2c5"},{"visibility":"simplified"}]},{"featureType":"road.highway","elementType":"labels.text","stylers":[{"color":"#4e4e4e"}]},{"featureType":"road.arterial","elementType":"geometry.fill","stylers":[{"color":"#f4f4f4"}]},{"featureType":"road.arterial","elementType":"labels.text.fill","stylers":[{"color":"#787878"}]},{"featureType":"road.arterial","elementType":"labels.icon","stylers":[{"visibility":"off"}]},{"featureType":"transit","elementType":"all","stylers":[{"visibility":"off"}]},{"featureType":"water","elementType":"all","stylers":[{"color":"#eaf6f8"},{"visibility":"on"}]},{"featureType":"water","elementType":"geometry.fill","stylers":[{"color":"#eaf6f8"}]}]
+      };
 
-    // Get the HTML DOM element that will contain your map
-    // We are using a div with id="event-map" seen below
-    var mapElement = document.getElementById('event-map');
-    map = new google.maps.Map(mapElement, mapOptions);
+      // Get the HTML DOM element that will contain your map
+      // We are using a div with id="event-map" seen below
+      var mapElement = document.getElementById('event-map');
+      map = new google.maps.Map(mapElement, mapOptions);
 
-  updateMarkers();
+      updateMarkers(data);
+    });
 }

--- a/source/javascripts/home.js
+++ b/source/javascripts/home.js
@@ -34,11 +34,10 @@ function buildEventsLists(options) {
   $.get("/events.json").done(
     function(data) {
       $.each(data, function(_index, value) {
-        var currentDate = Date.now()
         var event = value;
         var eventDate = Date.parse(event.date);
 
-        if (eventDate > Date.now()) {
+        if (eventIsUpcoming(eventDate)) {
           var eventListItem = buildUpcomingEventListItem(event);
           $upcomingEventsList.append(eventListItem);
         } else {
@@ -74,4 +73,9 @@ function buildPastEventListItem(event, classes) {
     event.hostName +
     "</p></a></li>";
   return element
+}
+
+function eventIsUpcoming(eventDate) {
+  var currentDate = Date.now()
+  return eventDate > currentDate;
 }

--- a/source/stylesheets/_events.scss
+++ b/source/stylesheets/_events.scss
@@ -7,6 +7,7 @@
   }
 
   .box {
+    margin-bottom: $largest-spacing;
 
     @include media($large-screen) {
       float: right;

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -72,6 +72,7 @@ $larger-spacing: ($large-spacing * 2);
 $largest-spacing: ($base-spacing * 3);
 $small-spacing: ($base-spacing * 0.85);
 $below-spacing: 4rem;
+$large-above-spacing: 40rem;
 $large-below-spacing: 9.5rem;
 
 // Animation timing


### PR DESCRIPTION
- Center the map on the first map marker on page load. "First" here means the first
  map marker that is drawn. If we enforce listing the events in
  `events.json` in chronological order, the first marker should always
  correspond to the most recently added upcoming event.
- Addresses https://github.com/plibmttbhgaty/plibmttbhgaty.github.io/issues/7

https://trello.com/c/NHBNidgC

Desktop:
![screen shot 2016-04-15 at 2 44 06 pm](https://cloud.githubusercontent.com/assets/1855523/14575898/d4b7200e-0319-11e6-9eeb-110a11ce6fc6.png)

iPad:
![screen shot 2016-04-15 at 2 43 44 pm](https://cloud.githubusercontent.com/assets/1855523/14575902/df264218-0319-11e6-9cc9-e559e18b7f32.png)

iPhone:
![screen shot 2016-04-15 at 2 43 23 pm](https://cloud.githubusercontent.com/assets/1855523/14575911/efca42ea-0319-11e6-88c6-a1238d16f70a.png)
